### PR TITLE
Image struct refactor

### DIFF
--- a/src/tests/test_image_struct.py
+++ b/src/tests/test_image_struct.py
@@ -1,0 +1,38 @@
+def test_image_struct():
+    from ttblit.core.struct import struct_blit_image
+    from ttblit.core.palette import Palette
+
+    def check_image(i, t):
+        b = struct_blit_image.build(i)
+        p = struct_blit_image.parse(b)
+        assert p.type == t
+        assert p.data.width == i['data']['width']
+        assert p.data.height == i['data']['height']
+        assert len(p.data.pixels) == i['data']['width'] * i['data']['height']
+        # Building from a parsed object should always yield an identical result
+        b1 = struct_blit_image.build(p)
+        assert b1 == b
+
+    # TODO: Use a real image to test?
+    palette = Palette()
+    palette.get_entry(255, 255, 255, 255)
+
+    image_dict = {
+        'data': {
+            'width': 0x10,
+            'height': 0x4,
+            'palette': palette.tostruct(),
+            'pixels': b'\x00' * 0x40,
+        }
+    }
+
+    check_image(image_dict, 'RL')
+
+    image_dict['type'] = 'RW'
+    check_image(image_dict, 'RW')
+
+    image_dict['type'] = 'PK'
+    check_image(image_dict, 'PK')
+
+    image_dict['type'] = 'RL'
+    check_image(image_dict, 'RL')

--- a/src/tests/test_palette.py
+++ b/src/tests/test_palette.py
@@ -1,0 +1,62 @@
+import pytest
+
+
+def test_palette_entries():
+    from ttblit.core.palette import Palette
+
+    palette = Palette()
+    assert len(palette) == 0
+
+    white = (255, 255, 255, 255)
+    black = (0, 0, 0, 255)
+    transparent_white = (255, 255, 255, 0)
+    transparent_black = (0, 0, 0, 0)
+    transparent_red = (255, 0, 0, 0)
+
+    # add
+    assert palette[palette.get_entry(*white)] == white
+    assert len(palette) == 1
+
+    # get existing
+    assert palette[palette.get_entry(*white)] == white
+    assert len(palette) == 1
+
+    # get existing (strict)
+    assert palette[palette.get_entry(*white)] == white
+    assert len(palette) == 1
+
+    # doesn't exist and can't add because strict
+    with pytest.raises(TypeError):
+        palette.get_entry(*black, strict=True)
+    assert len(palette) == 1
+
+    # add another
+    assert palette[palette.get_entry(*black)] == black
+    assert len(palette) == 2
+
+    # add a transparent colour
+    tw_index = palette.get_entry(*transparent_white)
+    assert len(palette) == 3
+
+    # should work because transparent white is the same as transparent black
+    assert palette.get_entry(*transparent_black, strict=True) == tw_index
+    assert len(palette) == 3
+
+    # should also not extend the palette in non-strict mode
+    assert palette.get_entry(*transparent_red) == tw_index
+    assert len(palette) == 3
+
+    # fill up the palette
+    for n in range(253):
+        palette.get_entry(n, 0, 255, 255)
+    assert len(palette) == 256
+
+    with pytest.raises(TypeError):
+        palette.get_entry(0, 255, 0, 255)
+    assert len(palette) == 256
+
+    # the resulting struct data should have same length as the source
+    assert len(palette.tostruct()) == len(palette)
+
+    # the iter should also have the same length
+    assert len(list(palette)) == len(palette)

--- a/src/ttblit/asset/builders/image.py
+++ b/src/ttblit/asset/builders/image.py
@@ -1,50 +1,11 @@
 import io
 import logging
-from math import ceil
 
-from bitstring import BitArray
 from PIL import Image
 
 from ...core.palette import Colour, Palette, type_palette
 from ...core.struct import struct_blit_image
 from ..builder import AssetBuilder
-
-
-def repetitions(seq):
-    """Input: sequence of values, Output: sequence of (value, repeat count)."""
-    i = iter(seq)
-    prev = next(i)
-    count = 1
-    for v in i:
-        if v == prev:
-            count += 1
-        else:
-            yield prev, count
-            prev = v
-            count = 1
-    yield prev, count
-
-
-def rle(data, bit_length):
-    """Input: data bytes, bit length, Output: RLE'd bytes"""
-    # TODO: This could be made more efficient by encoding the run-length
-    # as count-n, ie 0 means a run of n, where n = break_even. Then we
-    # can encode longer runs up to 255+n. But this needs changes in the
-    # blit engine.
-    break_even = ceil(8 / (bit_length + 1))
-    bits = BitArray()
-
-    for value, count in repetitions(data):
-        while count > break_even:
-            chunk = min(count, 0x100)
-            bits.append('0b1')
-            bits.append(bytes([chunk - 1]))
-            count -= chunk
-            bits.append(BitArray(uint=value, length=bit_length))
-        for x in range(count):
-            bits.append('0b0')
-            bits.append(BitArray(uint=value, length=bit_length))
-    return bits.tobytes()
 
 
 class ImageAsset(AssetBuilder):
@@ -94,28 +55,12 @@ class ImageAsset(AssetBuilder):
         # Since we already have bytes, we need to pass PIL an io.BytesIO object
         image = Image.open(io.BytesIO(input_data)).convert('RGBA')
         image = self.palette.quantize_image(image, transparent=self.transparent, strict=self.strict)
-
-        if self.packed:
-            bit_length = self.palette.bit_length()
-            image_data_rl = rle(image.tobytes(), bit_length)
-            image_data_pk = BitArray().join(BitArray(uint=x, length=bit_length) for x in image.tobytes()).tobytes()
-
-            if len(image_data_pk) < len(image_data_rl):
-                image_type = 'PK'
-                image_data = image_data_pk
-            else:
-                image_type = 'RL'
-                image_data = image_data_rl
-
-        else:
-            image_data = image.tobytes()
-            image_type = 'RW'
-
         return struct_blit_image.build({
-            'type': image_type,
-            'width': image.size[0],
-            'height': image.size[1],
-            'palette_entries': len(self.palette),
-            'palette': self.palette.tostruct(),
-            'data': image_data
+            'type': None if self.packed else 'RW',    # None means let the compressor decide
+            'data': {
+                'width': image.size[0],
+                'height': image.size[1],
+                'palette': self.palette.tostruct(),
+                'pixels': image.tobytes(),
+            },
         })

--- a/src/ttblit/core/compression.py
+++ b/src/ttblit/core/compression.py
@@ -1,0 +1,106 @@
+from math import ceil
+
+from bitstring import BitArray, Bits, ConstBitStream
+from construct import Adapter
+
+
+class RL:
+    @staticmethod
+    def repetitions(seq):
+        """Input: sequence of values, Output: sequence of (value, repeat count)."""
+        i = iter(seq)
+        prev = next(i)
+        count = 1
+        for v in i:
+            if v == prev:
+                count += 1
+            else:
+                yield prev, count
+                prev = v
+                count = 1
+        yield prev, count
+
+    @staticmethod
+    def compress(data, bit_length):
+        """Input: data bytes, bit length, Output: RLE'd bytes"""
+        # TODO: This could be made more efficient by encoding the run-length
+        # as count-n, ie 0 means a run of n, where n = break_even. Then we
+        # can encode longer runs up to 255+n. But this needs changes in the
+        # blit engine.
+        break_even = ceil(8 / (bit_length + 1))
+        bits = BitArray()
+
+        for value, count in RL.repetitions(data):
+            while count > break_even:
+                chunk = min(count, 0x100)
+                bits.append('0b1')
+                bits.append(bytes([chunk - 1]))
+                count -= chunk
+                bits.append(BitArray(uint=value, length=bit_length))
+            for x in range(count):
+                bits.append('0b0')
+                bits.append(BitArray(uint=value, length=bit_length))
+        return bits.tobytes()
+
+    @staticmethod
+    def decompress(data, bit_length, output_length):
+        stream = ConstBitStream(bytes=data)
+        result = []
+        while len(result) < output_length:
+            t = stream.read(1)
+            if t:
+                count = stream.read(8).uint + 1
+            else:
+                count = 1
+            result.extend([stream.read(bit_length).uint] * count)
+        return bytes(result)
+
+
+class PK:
+    @staticmethod
+    def compress(data, bit_length):
+        return BitArray().join(BitArray(uint=x, length=bit_length) for x in data).tobytes()
+
+    @staticmethod
+    def decompress(data, bit_length, num_pixels):
+        return bytes(i.uint for i in Bits(bytes=data).cut(bit_length))
+
+
+packers = {cls.__name__: cls for cls in (PK, RL)}
+
+
+class ImageCompressor(Adapter):
+
+    def bit_length(self, obj):
+        """Compute the required bit length for image data.
+        Uses the count of items in the palette to determine how
+        densely we can pack the image data.
+        """
+        if obj.get('type', None) == "RW":
+            return 8
+        else:
+            return max(1, (len(obj['data']['palette']) - 1).bit_length())
+
+    def num_pixels(self, obj):
+        return obj['data']['width'] * obj['data']['height']
+
+    def _decode(self, obj, context, path):
+        if obj['type'] != 'RW':
+            obj['data']['pixels'] = packers[obj['type']].decompress(
+                obj['data']['pixels'], self.bit_length(obj), self.num_pixels(obj)
+            )
+        return obj
+
+    def _encode(self, obj, context, path):
+        obj = obj.copy()   # we are going to mutate this, so make a deep copy
+        obj['data'] = obj['data'].copy()
+        bl = self.bit_length(obj)
+        if obj.get('type', None) is None:
+            all_comp = [(k, v.compress(obj['data']['pixels'], bl)) for k, v in packers.items()]
+            best = min(all_comp, key=lambda x: len(x[1]))
+            # Put the best type back into the object.
+            obj['type'] = best[0]
+            obj['data']['pixels'] = best[1]
+        elif obj['type'] != 'RW':
+            obj['data']['pixels'] = packers[obj['type']].compress(obj['data']['pixels'], bl)
+        return obj

--- a/src/ttblit/core/palette.py
+++ b/src/ttblit/core/palette.py
@@ -24,7 +24,7 @@ class Palette():
         self.transparent = None
         self.entries = []
 
-        if type(palette_file) is Palette:
+        if isinstance(palette_file, Palette):
             self.transparent = palette_file.transparent
             self.entries = palette_file.entries
             return
@@ -143,28 +143,11 @@ class Palette():
         else:
             raise TypeError(f'Colour {r}, {g}, {b}, {a} does not exist in palette!')
 
-    def tolist(self):
-        result = []
-        for r, g, b, a in self.entries:
-            result.append(r)
-            result.append(g)
-            result.append(b)
-            result.append(a)
-        return result
-
-    def tobytes(self):
-        return bytes(self.tolist())
-
     def tostruct(self):
-        result = []
-        for r, g, b, a in self.entries:
-            result.append({
-                'r': r,
-                'g': g,
-                'b': b,
-                'a': a,
-            })
-        return result
+        return [dict(zip('rgba', c)) for c in self.entries]
+
+    def __iter__(self):
+        return iter(self.entries)
 
     def __len__(self):
         return len(self.entries)
@@ -177,7 +160,7 @@ def type_palette(palette_file):
     # Only used as a type in argparse.
     # This wrapper around Palette traps errors and
     # raises in a way that's visible to the user
-    if type(palette_file) is Palette:
+    if isinstance(palette_file, Palette):
         return palette_file
 
     try:

--- a/src/ttblit/core/palette.py
+++ b/src/ttblit/core/palette.py
@@ -107,6 +107,21 @@ class Palette():
 
         self.image = palette.convert('RGBA')
 
+    def quantize_image(self, image, transparent=None, strict=False):
+        if strict and len(self) == 0:
+            raise TypeError("Attempting to enforce strict colours with an empty palette, did you really want to do this?")
+        w, h = image.size
+        output_image = Image.new('P', (w, h))
+        for y in range(h):
+            for x in range(w):
+                r, g, b, a = image.getpixel((x, y))
+                if transparent is not None and (r, g, b) == tuple(transparent):
+                    a = 0x00
+                index = self.get_entry(r, g, b, a, strict=strict)
+                output_image.putpixel((x, y), index)
+
+        return output_image
+
     def get_entry(self, r, g, b, a, remap_transparent=True, strict=False):
         if (r, g, b, a) in self.entries:
             index = self.entries.index((r, g, b, a))

--- a/src/ttblit/core/palette.py
+++ b/src/ttblit/core/palette.py
@@ -166,9 +166,6 @@ class Palette():
             })
         return result
 
-    def bit_length(self):
-        return max(1, len(self.entries) - 1).bit_length()
-
     def __len__(self):
         return len(self.entries)
 


### PR DESCRIPTION
This make Construct handle image compression internally as part of parsing and building. Allows a lot of random code from throughout the repo to be gathered in one place.

This needs testing, specifically wrt #9 which it may have either fixed or regressed.
