### PR TITLE
Remap and struct options for tmx maps

### DIFF
--- a/src/tests/test_map.py
+++ b/src/tests/test_map.py
@@ -46,7 +46,7 @@ def test_map_tiled_struct(subparser):
 </map>
 ''')
     # Tile indexes 1, 2, 3, 4 will be remapped -1 to 0, 1, 2, 3
-    assert output == struct.pack('4sHHH4B', b'MTMX', 4, 1, 1, 0, 1, 2, 3)
+    assert output == struct.pack('<4sBHHH4B', b'MTMX', 0, 4, 1, 1, 0, 1, 2, 3)
 
 
 def test_map_empty_tiled_remap_empty(subparser):

--- a/src/tests/test_map.py
+++ b/src/tests/test_map.py
@@ -1,4 +1,5 @@
 import argparse
+import struct
 
 import pytest
 
@@ -26,3 +27,43 @@ def test_map_tiled(subparser):
 ''')
 
     assert output == b'\x00'
+
+
+def test_map_tiled_struct(subparser):
+    from ttblit.asset.builders import map
+
+    map = map.MapAsset(subparser)
+
+    map.output_struct = True
+
+    output = map.tiled_to_binary('''<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="4" height="1" tilewidth="8" tileheight="8" infinite="0" nextlayerid="2" nextobjectid="1">
+ <layer id="1" name="Tile Layer 1" width="1" height="1">
+  <data encoding="csv">
+1,2,3,4
+</data>
+ </layer>
+</map>
+''')
+    # Tile indexes 1, 2, 3, 4 will be remapped -1 to 0, 1, 2, 3
+    assert output == struct.pack('4sHHH4B', b'MTMX', 4, 1, 1, 0, 1, 2, 3)
+
+
+def test_map_empty_tiled_remap_empty(subparser):
+    from ttblit.asset.builders import map
+
+    map = map.MapAsset(subparser)
+
+    map.empty_tile = 255
+
+    output = map.tiled_to_binary('''<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="2" height="1" tilewidth="8" tileheight="8" infinite="0" nextlayerid="2" nextobjectid="1">
+ <layer id="1" name="Tile Layer 1" width="1" height="1">
+  <data encoding="csv">
+1,0
+</data>
+ </layer>
+</map>
+''')
+
+    assert output == b'\x00\xFF'

--- a/src/ttblit/asset/builders/map.py
+++ b/src/ttblit/asset/builders/map.py
@@ -44,7 +44,7 @@ class MapAsset(RawAsset):
             layers = len(layer_data)
 
             map_data = bytes('MTMX', encoding='utf-8')
-            map_data += struct.pack('<HHH', width, height, layers)
+            map_data += struct.pack('<BHHH', self.empty_tile, width, height, layers)
             map_data += b''.join(layer_data)
 
             return map_data

--- a/src/ttblit/asset/builders/map.py
+++ b/src/ttblit/asset/builders/map.py
@@ -1,3 +1,5 @@
+import struct
+
 from .raw import RawAsset
 
 
@@ -9,20 +11,46 @@ class MapAsset(RawAsset):
         'tiled': ('.tmx', '.raw'),
     }
 
+    def __init__(self, parser=None):
+        self.options.update({
+            'empty_tile': (int, 0),
+            'output_struct': (bool, False)
+        })
+
+        RawAsset.__init__(self, parser)
+
+        self.empty_tile = 0
+        self.output_struct = False
+
+        if self.parser is not None:
+            self.parser.add_argument('--empty-tile', type=int, default=0, help='Remap .tmx empty tiles')
+            self.parser.add_argument('--output-struct', type=bool, default=False, help='Output .tmx as struct with level width/height, etc')
+
     def tiled_to_binary(self, input_data):
         from xml.etree import ElementTree as ET
         root = ET.fromstring(input_data)
         layers = root.findall('layer/data')
-        data = []
-        for layer in layers:
-            try:
-                data.append(self.csv_to_binary(
-                    layer.text,
-                    base=10,
-                    offset=-1))  # Tiled indexes from 1 rather than 0
-            except ValueError:
-                raise RuntimeError("Failed to convert .tmx, does it contain blank (0) tiles? Tiled is 1-indexed, so these get converted to -1 and blow everyting up")
-        return b''.join(data)
+        map_data = root.find('map')
+        layer_data = []
+        for layer_csv in layers:
+            layer = self.csv_to_list(layer_csv.text, 10)
+            # Shift 1-indexed tiles to 0-indexed, and remap empty tile (0) to specified index
+            layer = [self.empty_tile if i == 0 else i - 1 for i in layer]
+            layer_data.append(bytes(layer))
+
+        if self.output_struct:  # Fancy struct
+            width = int(root.get("width"))
+            height = int(root.get("height"))
+            layers = len(layer_data)
+
+            map_data = bytes('MTMX', encoding='utf-8')
+            map_data += struct.pack('<HHH', width, height, layers)
+            map_data += b''.join(layer_data)
+
+            return map_data
+
+        else:  # Just return the raw layer data (legacy compatibility mode)
+            return b''.join(layer_data)
 
     def to_binary(self, input_data):
         if self.input_type == 'tiled':

--- a/src/ttblit/asset/builders/raw.py
+++ b/src/ttblit/asset/builders/raw.py
@@ -10,12 +10,11 @@ class RawAsset(AssetBuilder):
         'csv': ('.csv')
     }
 
-    def csv_to_binary(self, input_data, base=10, offset=0):
-        try:
+    def csv_to_list(self, input_data, base):
+        if type(input_data) == bytes:
             input_data = input_data.decode('utf-8')
-        except AttributeError:
-            pass
 
+        # Strip leading/trailing whitespace
         input_data = input_data.strip()
 
         # Replace '1, 2, 3' to '1,2,3', might as well do it here
@@ -29,11 +28,12 @@ class RawAsset(AssetBuilder):
 
         # Flatten our rows/cols 2d array into a 1d array of bytes
         # Might as well do the int conversion here, to save another loop
-        input_data = [(int(col, base) + offset) for row in input_data for col in row if col != '']
+        return [int(col, base) for row in input_data for col in row if col != '']
 
-        return bytes(input_data)
+    def csv_to_binary(self, input_data, base):
+        return bytes(self.csv_to_list(input_data, base))
 
     def to_binary(self, input_data):
         if self.input_type == 'csv':
-            input_data = self.csv_to_binary(input_data, base=10)
+            input_data = bytes(self.csv_to_list(input_data, base=10))
         return input_data


### PR DESCRIPTION
Adds new options for "map" types- currently we only support "tmx" so I wonder if "AssetMap" and "map" should globally be "tmx" and future map formats should have their own class.

New options:
1. `--empty-tile` or `empty_tile` - specifies the tile which 0-indexed (empty) tiles will be remapped to. Defaults to 0. All other tile indexes are offset by -1 to give 0-based tile indexes into our spritesheets so `0` has to go *somewhere*
2. `--output-struct` or `output_struct` - the asset builder will output a struct with some basic map info, instead of just a raw binary of the layers.

The struct looks like:

```
"MTMX"  - 4 bytes, utf8 encoded
width - 2 bytes unsigned uint16_t
height - 2 bytes unsigned uint16_t
layers - 2 bytes unsigned uint16_t
data - width * height * layers bytes (uint8_t) of map data
```