### PR TITLE
Set minimum required Click version to 7.0

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 python_requires = >= 3.4
 packages = find:
 install_requires =
-    click
+	click>=7.0
 	pillow
 	pyyaml
 	bitstring


### PR DESCRIPTION
This is needed for case insensitive choice options.