### PR TITLE
Set minimum version number of dependency

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 python_requires = >= 3.4
 packages = find:
 install_requires =
-    click
+    	click>=7
 	pillow
 	pyyaml
 	bitstring


### PR DESCRIPTION
If click is not fixed to a minimum version number it has the potential to crash the 32blit tool when executed resulting in a broken build of a 32blit game.