### PR TITLE
Add a launch command and a --launch flag to install

### DIFF
--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -5,7 +5,7 @@ import click
 
 from .asset.builder import AssetTool
 from .tool.cmake import cmake_cli
-from .tool.flasher import flash_cli, install_cli
+from .tool.flasher import flash_cli, install_cli, launch_cli
 from .tool.metadata import metadata_cli
 from .tool.packer import pack_cli
 from .tool.relocs import relocs_cli
@@ -23,6 +23,7 @@ for n, c in AssetTool._commands.items():
 main.add_command(cmake_cli)
 main.add_command(flash_cli)
 main.add_command(install_cli)
+main.add_command(launch_cli)
 main.add_command(metadata_cli)
 main.add_command(pack_cli)
 main.add_command(relocs_cli)

--- a/src/ttblit/core/blitserial.py
+++ b/src/ttblit/core/blitserial.py
@@ -114,6 +114,11 @@ class BlitSerial(serial.Serial):
         with open(file, 'rb') as file:
             progress = tqdm(total=file_size, desc="Flashing...", unit_scale=True, unit_divisor=1024, unit="B", ncols=70, dynamic_ncols=True)
             while sent_byte_count < file_size:
+                # if we received something, there was an error
+                if self.in_waiting:
+                    progress.close()
+                    break
+
                 data = file.read(chunk_size)
                 self.write(data)
                 self.flush()

--- a/src/ttblit/core/blitserial.py
+++ b/src/ttblit/core/blitserial.py
@@ -148,3 +148,7 @@ class BlitSerial(serial.Serial):
             yield (meta, offset, size)
 
             offset_str = self.read(4)
+
+    @firmware_command
+    def launch(self, filename):
+        self.write(f'32BLLNCH{filename}\x00'.encode('ascii'))

--- a/src/ttblit/tool/flasher.py
+++ b/src/ttblit/tool/flasher.py
@@ -121,3 +121,10 @@ def install_cli(blitserial, source, destination):
             destination = pathlib.PurePosixPath('/') / destination
 
     blitserial.send_file(source, drive, destination)
+
+
+@click.command('launch', help="Launch a game/file on 32Blit")
+@serial_command
+@click.argument("filename", type=str, required=True)
+def launch_cli(blitserial, filename):
+    blitserial.launch(filename)

--- a/src/ttblit/tool/flasher.py
+++ b/src/ttblit/tool/flasher.py
@@ -110,7 +110,8 @@ def info(blitserial):
 @serial_command
 @click.argument("source", type=pathlib.Path, required=True)
 @click.argument("destination", type=pathlib.PurePosixPath, default=None, required=False)
-def install_cli(blitserial, source, destination):
+@click.option("--launch/--no-launch", default=False)
+def install_cli(blitserial, source, destination, launch):
     if destination is None and source.suffix.lower() == '.blit':
         drive = 'flash'
     else:
@@ -120,7 +121,7 @@ def install_cli(blitserial, source, destination):
         elif not destination.is_absolute():
             destination = pathlib.PurePosixPath('/') / destination
 
-    blitserial.send_file(source, drive, destination)
+    blitserial.send_file(source, drive, destination, launch)
 
 
 @click.command('launch', help="Launch a game/file on 32Blit")


### PR DESCRIPTION
This goes with https://github.com/32blit/32blit-sdk/pull/605 to finish making launching after flash optional. It also allows launching after saving a file to the SD card.