### PR TITLE
Support for 16bit tmx tile indexes, replaces #74

### DIFF
--- a/src/tests/test_map.py
+++ b/src/tests/test_map.py
@@ -17,7 +17,7 @@ def test_map_tiled():
     assert output == b'\x00'
 
 
-def test_map_tiled_struct():
+def test_map_tiled_struct_8bit():
     from ttblit.asset.builders import map
 
     output = map.map.build('''<?xml version="1.0" encoding="UTF-8"?>
@@ -31,6 +31,23 @@ def test_map_tiled_struct():
 ''', 'tiled', output_struct=True)
     # Tile indexes 1, 2, 3, 4 will be remapped -1 to 0, 1, 2, 3
     assert output == struct.pack('<4sBHHH4B', b'MTMX', 0, 4, 1, 1, 0, 1, 2, 3)
+
+
+def test_map_tiled_struct_16bit():
+    from ttblit.asset.builders import map
+
+    output = map.map.build('''<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.2" orientation="orthogonal" renderorder="right-down" compressionlevel="-1" width="4" height="1" tilewidth="8" tileheight="8" infinite="0" nextlayerid="2" nextobjectid="1">
+ <layer id="1" name="Tile Layer 1" width="1" height="1">
+  <data encoding="csv">
+256,257,258,259
+</data>
+ </layer>
+</map>
+''', 'tiled', output_struct=True)
+    # Tile indexes 256, 257, 258, 259 will be remapped -1 to 255, 256, 257, 258
+    # output tile data will be 16bit!
+    assert output == struct.pack('<4sBHHH4H', b'MTMX', 0, 4, 1, 1, 255, 256, 257, 258)
 
 
 def test_map_tiled_layer_reorder():


### PR DESCRIPTION
Per discussion in Discord this PR replaces #74 with some tweaks to canonicalise on `struct.pack` for both 8bit and 16bit tile formats. The data produced is `uint8_t` in both cases, but data for 16bit tiles will be twice the size and require a slightly different `TMX` struct to work with:

```c++
struct TMX16 {
    char head[4];
    uint8_t empty_tile;
    uint16_t width;
    uint16_t height;
    uint16_t layers;
    uint16_t data[];
};
```