### PR TITLE
Handle tiled transforms

### DIFF
--- a/src/ttblit/asset/builders/map.py
+++ b/src/ttblit/asset/builders/map.py
@@ -27,7 +27,8 @@ def tiled_to_binary(data, empty_tile, output_struct):
     for layer_csv in layers:
         layer = csv_to_list(layer_csv.find('data').text, 10)
         # Shift 1-indexed tiles to 0-indexed, and remap empty tile (0) to specified index
-        layer = [empty_tile if i == 0 else i - 1 for i in layer]
+        # The highest three bits store the transform
+        layer = [empty_tile if i == 0 else (i & 0x1FFFFFFF) - 1 for i in layer]
 
         if max(layer) > 255 and not use_16bits:
             # Let's assume it's got 2-byte tile indices


### PR DESCRIPTION
Tiled stores transforms in the highest 3 bits of the tile index:
- (1 << 31) = H Flip
- (1 << 30) = V Flip
- (1 << 29) = X/Y Swap

Shifted down, this matches what TileMap/Map expect. This is different to SpriteTransform though... (H flip and swap x/y are the other way around...)

I'm just appending the transform data after the tiles, maybe this should be optional to not make maps twice the size if you're not using them?

(Layer 0 tiles, layer 1 tiles, ... layer 0 transforms, layer 1 transforms)