### PR TITLE
Add the DFU tool

### DIFF
--- a/src/tests/test_dfu_cli.py
+++ b/src/tests/test_dfu_cli.py
@@ -1,0 +1,66 @@
+
+import tempfile
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def test_output_file():
+    return tempfile.NamedTemporaryFile('wb', suffix='.dfu')
+
+
+def test_dfu_build(test_resources, test_output_file):
+    from ttblit import main
+
+    with pytest.raises(SystemExit):
+        main([
+            'dfu',
+            'build',
+            '--input-file', str(test_resources / 'doom-fire.bin'),
+            '--output-file', test_output_file.name
+        ])
+
+
+def test_dfu_read(test_resources, test_output_file):
+    from ttblit import main
+
+    with pytest.raises(SystemExit):
+        main([
+            'dfu',
+            'build',
+            '--input-file', str(test_resources / 'doom-fire.bin'),
+            '--output-file', test_output_file.name
+        ])
+
+    with pytest.raises(SystemExit):
+        main([
+            'dfu',
+            'read',
+            '--input-file', test_output_file.name
+        ])
+
+
+def test_dfu_dump(test_resources, test_output_file):
+    from ttblit import main
+
+    with pytest.raises(SystemExit):
+        main([
+            'dfu',
+            'build',
+            '--input-file', str(test_resources / 'doom-fire.bin'),
+            '--output-file', test_output_file.name
+        ])
+
+    with pytest.raises(SystemExit):
+        main([
+            'dfu',
+            'dump',
+            '--input-file', test_output_file.name
+        ])
+
+    output_bin_file = pathlib.Path(test_output_file.name.replace('.dfu','-0-0x08000000.bin'))
+
+    assert output_bin_file.is_file()
+
+    output_bin_file.unlink()

--- a/src/tests/test_setup.py
+++ b/src/tests/test_setup.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 import tempfile
 
+
 def test_visualstudio_windows():
     from ttblit.tool.setup import visualstudio_config
 

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38},qa
+envlist = py{37,38,39},qa
 skip_missing_interpreters = True
 
 [testenv]

--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -1,8 +1,9 @@
 
 __version__ = '0.7.0'
 
-import click
 import logging
+
+import click
 
 from .asset.builder import AssetTool
 from .tool.cmake import cmake_cli

--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -6,6 +6,7 @@ import logging
 
 from .asset.builder import AssetTool
 from .tool.cmake import cmake_cli
+from .tool.dfu import dfu_cli
 from .tool.flasher import flash_cli, install_cli, launch_cli
 from .tool.metadata import metadata_cli
 from .tool.packer import pack_cli
@@ -35,6 +36,7 @@ main.add_command(metadata_cli)
 main.add_command(pack_cli)
 main.add_command(relocs_cli)
 main.add_command(setup_cli)
+main.add_command(dfu_cli)
 
 
 @main.command(help='Print version and exit')

--- a/src/ttblit/asset/builders/map.py
+++ b/src/ttblit/asset/builders/map.py
@@ -59,7 +59,7 @@ def tiled_to_binary(data, empty_tile, output_struct):
 
         if use_16bits:
             flags |= (1 << 0)
-        
+
         if have_transforms:
             flags |= (1 << 1)
         else:

--- a/src/ttblit/core/dfu.py
+++ b/src/ttblit/core/dfu.py
@@ -1,0 +1,171 @@
+import pathlib
+import zlib
+
+import construct
+from construct import (Checksum, Const, CString, Flag, GreedyBytes,
+                       GreedyRange, Hex, Int8ul, Int16ul, Int32ul, Padded,
+                       Padding, Prefixed, RawCopy, Rebuild, Struct, len_, this)
+
+DFU_SIGNATURE = b'DfuSe'
+DFU_size = Rebuild(Int32ul, 0)
+
+
+def DFU_file_length(ctx):
+    '''Compute the entire file size + 4 bytes for CRC
+    The total DFU file length is ostensibly the actual
+    length in bytes of the resulting file.
+    However DFU File Manager does not seem to agree,
+    since it's output size is 16 bytes short.
+    Since this is suspiciously the same as the suffix
+    length in bytes, we omit that number to match
+    DFU File Manager's output.
+    '''
+    size = 11        # DFU Header Length
+    # size += 16     # DFU Suffix Length
+    for target in ctx.targets:
+        # Each target has a 274 byte header consisting
+        # of the following fields:
+        size += Const(DFU_SIGNATURE).sizeof()          # szSignature ('Target' in bytes)
+        size += Int8ul.sizeof()                        # bAlternateSetting
+        size += Int8ul.sizeof()                        # bTargetNamed
+        size += Padding(3).sizeof()                    # Padding
+        size += Padded(255, CString('utf8')).sizeof()  # szTargetName
+        size += Int32ul.sizeof()                       # dwTargetSize
+        size += Int32ul.sizeof()                       # dwNbElements
+        size += DFU_target_size(target)
+
+    return size
+
+
+def DFU_target_size(ctx):
+    '''Returns the size of the target binary data, plus the
+    dwElementAddress header, and dwElementSize byte count.
+    '''
+    size = 0
+
+    try:
+        images = ctx.images
+    except AttributeError:
+        images = ctx['images']
+
+    size += sum([DFU_image_size(image) for image in images])
+    return size
+
+
+def DFU_image_size(image):
+    return len(image['data']) + Int32ul.sizeof() + Int32ul.sizeof()
+
+
+DFU_image = Struct(
+    'dwElementAddress' / Hex(Int32ul),     # Data offset address for image
+    'data' / Prefixed(Int32ul, GreedyBytes)
+)
+
+DFU_target = Struct(
+    'szSignature' / Const(b'Target'),      # DFU target identifier
+    'bAlternateSetting' / Int8ul,          # Gives device alternate setting for which this image can be used
+    'bTargetNamed' / Flag,                 # Boolean determining if the target is named
+    Padding(3),                            # Mystery bytes!
+    'szTargetName' / Padded(255, CString('utf8')),         # Target name
+                                                           # DFU File Manager does not initialise this
+                                                           # memory, so our file will not exactly match
+                                                           # its output.
+    'dwTargetSize' / Rebuild(Int32ul, DFU_target_size),    # Total size of target images
+    'dwNbElements' / Rebuild(Int32ul, len_(this.images)),  # Count the number of target images
+    'images' / GreedyRange(DFU_image)
+)
+
+DFU_body = Struct(
+    'szSignature' / Const(DFU_SIGNATURE),  # DFU format identifier (changes on major revisions)
+    'bVersion' / Const(1, Int8ul),         # DFU format revision   (changes on minor revisions)
+    'DFUImageSize' / Rebuild(Int32ul, DFU_file_length),    # Total DFU file length in bytes
+    'bTargets' / Rebuild(Int8ul, len_(this.targets)),      # Number of targets in the file
+
+    'targets' / GreedyRange(DFU_target),
+
+    'bcdDevice' / Int16ul,                 # Firmware version, or 0xffff if ignored
+    'idProduct' / Hex(Int16ul),            # USB product ID or 0xffff to ignore
+    'idVendor' / Hex(Int16ul),             # USB vendor ID or 0xffff to ignore
+    'bcdDFU' / Const(0x011A, Int16ul),     # DFU specification number
+    'ucDfuSignature' / Const(b'UFD'),      # 0x44, 0x46 and 0x55 ie 'DFU' but reversed
+    'bLength' / Const(16, Int8ul)          # Length of the DFU suffix in bytes
+)
+
+DFU = Struct(
+    'fields' / RawCopy(DFU_body),
+    'dwCRC' / Checksum(Int32ul,            # CRC calculated over the whole file, except for itself
+                       lambda data: 0xffffffff ^ zlib.crc32(data),
+                       this.fields.data)
+)
+
+
+def display_dfu_info(parsed):
+    print(f'''
+Device: {parsed.fields.value.bcdDevice}
+Target: {parsed.fields.value.idProduct:04x}:{parsed.fields.value.idVendor:04x}
+Size: {parsed.fields.value.DFUImageSize:,} bytes
+Targets: {parsed.fields.value.bTargets}''')
+    for target in parsed.fields.value.targets:
+        print(f'''
+    Name: {target.szTargetName}
+    Alternate Setting: {target.bAlternateSetting}
+    Size: {target.dwTargetSize:,} bytes
+    Images: {target.dwNbElements}''')
+        for image in target.images:
+            print(f'''
+        Offset: {image.dwElementAddress}
+        Size: {len(image.data):,} bytes
+''')
+
+
+def build(input_file, output_file, address, force=False, id_product=0x0000, id_vendor=0x0483):
+    if not output_file.parent.is_dir():
+        raise RuntimeError(f'Output directory "{output_file.parent}" does not exist!')
+    elif output_file.is_file() and not force:
+        raise RuntimeError(f'Existing output file "{output_file}", use --force to overwrite!')
+
+    if not input_file.suffix == ".bin":
+        raise RuntimeError(f'Input file "{input_file}", is not a .bin file?')
+
+    output = DFU.build({'fields': {'value': {
+        'targets': [{
+            'bAlternateSetting': 0,
+            'bTargetNamed': True,
+            'szTargetName': 'ST...',
+            'images': [{
+                'dwElementAddress': address,
+                'data': open(input_file, 'rb').read()
+            }]
+        }],
+        'bcdDevice': 0,
+        'idProduct': id_product,
+        'idVendor': id_vendor
+    }}})
+
+    open(output_file, 'wb').write(output)
+
+
+def read(input_file):
+    try:
+        return DFU.parse(open(input_file, 'rb').read())
+    except construct.core.ConstructError as error:
+        RuntimeError(f'Invalid dfu file {input_file} ({error})')
+
+
+def dump(input_file, force=False):
+    parsed = read(input_file)
+
+    for target in parsed.fields.value.targets:
+        target_id = target.bAlternateSetting
+        for image in target.images:
+            address = image.dwElementAddress
+            data = image.data
+            dest = str(input_file).replace('.dfu', '')
+            filename = f"{dest}-{target_id}-{address}.bin"
+
+            if pathlib.Path(filename).is_file() and not force:
+                raise RuntimeError(f'Existing output file "{filename}", use --force to overwrite!')
+
+            print(f"Dumping image at {address} to {filename} ({len(data)} bytes)")
+
+            open(filename, 'wb').write(data)

--- a/src/ttblit/tool/dfu.py
+++ b/src/ttblit/tool/dfu.py
@@ -1,0 +1,33 @@
+import pathlib
+
+import click
+
+from ..core import dfu
+
+
+@click.group('dfu', help='Pack or unpack DFU files')
+def dfu_cli():
+    pass
+
+
+@dfu_cli.command(help='Pack a .bin file into a DFU file')
+@click.option('--input-file', type=pathlib.Path, help='Input .bin', required=True)
+@click.option('--output-file', type=pathlib.Path, help='Output .dfu', required=True)
+@click.option('--address', type=int, help='Offset address', default=0x08000000)
+@click.option('--force/--no-force', help='Force file overwrite', default=True)
+def build(input_file, output_file, address, force):
+    dfu.build(input_file, output_file, address, force)
+
+
+@dfu_cli.command(help='Dump the .bin parts of a DFU file')
+@click.option('--input-file', type=pathlib.Path, help='Input .bin', required=True)
+@click.option('--force/--no-force', help='Force file overwrite', default=True)
+def dump(input_file, force):
+    dfu.dump(input_file, force)
+
+
+@dfu_cli.command(help='Read information from a DFU file')
+@click.option('--input-file', type=pathlib.Path, help='Input .bin', required=True)
+def read(input_file):
+    parsed = dfu.read(input_file)
+    dfu.display_dfu_info(parsed)

--- a/src/ttblit/tool/setup.py
+++ b/src/ttblit/tool/setup.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 import pathlib
 import re
 import shutil
@@ -8,6 +8,7 @@ import subprocess
 import textwrap
 
 import click
+
 
 # check environment before prompting
 class SetupCommand(click.Command):
@@ -45,7 +46,7 @@ class SetupCommand(click.Command):
                         failed = True
 
                 logging.info(f'Found {name} version {found_version_str} (required {version_str})')
-            except:
+            except subprocess.CalledProcessError:
                 logging.critical(f'Could not find {name}!')
                 failed = True
 
@@ -54,6 +55,7 @@ class SetupCommand(click.Command):
             raise click.Abort()
 
         super().parse_args(ctx, args)
+
 
 def install_sdk(sdk_path):
     click.echo('Installing SDK...')
@@ -65,20 +67,21 @@ def install_sdk(sdk_path):
     latest_tag = result.stdout.strip()
     result = subprocess.run(['git', 'checkout', latest_tag], cwd=sdk_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
+
 def vscode_config(project_path, sdk_path):
     (project_path / '.vscode').mkdir()
 
-    open(project_path / '.vscode' / 'settings.json','w').write(textwrap.dedent(
+    open(project_path / '.vscode' / 'settings.json', 'w').write(textwrap.dedent(
         '''
         {
             "cmake.configureSettings": {
                 "32BLIT_DIR": "{sdk_path}"
             },
             "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
-        } 
+        }
         '''.replace('{sdk_path}', str(sdk_path).replace('\\', '\\\\'))))
 
-    open(project_path / '.vscode' / 'cmake-kits.json','w').write(textwrap.dedent(
+    open(project_path / '.vscode' / 'cmake-kits.json', 'w').write(textwrap.dedent(
         '''
         [
             {
@@ -88,8 +91,9 @@ def vscode_config(project_path, sdk_path):
         ]
         '''.replace('{sdk_path}', str(sdk_path).replace('\\', '\\\\'))))
 
+
 def visualstudio_config(project_path, sdk_path):
-    open(project_path / 'CMakeSettings.json','w').write(textwrap.dedent(
+    open(project_path / 'CMakeSettings.json', 'w').write(textwrap.dedent(
         '''
         {
             "configurations": [
@@ -160,6 +164,7 @@ def visualstudio_config(project_path, sdk_path):
             ]
         }
         '''.replace('{sdk_path}', str(sdk_path).replace('\\', '\\\\'))))
+
 
 @click.command('setup', help='Setup a project', cls=SetupCommand)
 @click.option('--project-name', prompt=True)


### PR DESCRIPTION
Finally addresses #49 and brings the DFU tool under the 32blit tools umbrella where it - hopefully - wont be so neglected.

This is really only a utility for packing the output .bin files into a DFU-compatible file and is mostly only useful for Windows folks using DFuSe Demo to perform a firmware upgrade.

Could be useful for alt firmware dev and other stuff though...