### PR TITLE
Set break_on_hyphens=False to optimise C output

### DIFF
--- a/src/ttblit/asset/formatters/c.py
+++ b/src/ttblit/asset/formatters/c.py
@@ -3,7 +3,7 @@ import textwrap
 from ..formatter import AssetFormatter
 
 wrapper = textwrap.TextWrapper(
-    initial_indent='    ', subsequent_indent='    ', width=80
+    break_on_hyphens=False, initial_indent='    ', subsequent_indent='    ', width=80
 )
 
 


### PR DESCRIPTION
Causes `TextWrapper.fill` to use a simpler regex, speeding up big arrays a bit.

Minor change found while messing around with build profiling... (voxel/mp3 were taking a while to handle assets). Could probably be reworked further to not join, then immediately re-split in textwrap... but I'm already getting distracted :laughing: .

Makes a clean debug build of the voxel example ~1 second faster (from a ~18s single-threaded build)
