### PR TITLE
Asset packer generates function for getting asset by name

### DIFF
--- a/src/ttblit/asset/builder.py
+++ b/src/ttblit/asset/builder.py
@@ -106,7 +106,7 @@ class AssetTool:
         @functools.wraps(f)
         def cmd(input_file, input_type, output_file, output_format, symbol_name, force, **kwargs):
             aw = AssetWriter()
-            aw.add_asset(symbol_name, f(input_file, input_type, **kwargs))
+            aw.add_asset(symbol_name, f(input_file, input_type, **kwargs), input_file)
             aw.write(output_format, output_file, force, report=False)
 
         self._commands[self.name] = cmd

--- a/src/ttblit/asset/writer.py
+++ b/src/ttblit/asset/writer.py
@@ -8,10 +8,10 @@ class AssetWriter:
     def __init__(self):
         self._assets = {}
 
-    def add_asset(self, symbol, data):
+    def add_asset(self, symbol, data, path):
         if symbol in self._assets:
             raise NameError(f'Symbol {symbol} has already been added.')
-        self._assets[symbol] = data
+        self._assets[symbol] = {"data": data, "path":path}
 
     def _sorted(self, sort):
         if sort is None:
@@ -19,7 +19,7 @@ class AssetWriter:
         elif sort == 'symbol':
             return sorted(self._assets.items())
         elif sort == 'size':
-            return sorted(self._assets.items(), key=lambda i: len(i[1]))
+            return sorted(self._assets.items(), key=lambda i: len(i.data[1]))
         else:
             raise ValueError(f"Don't know how to sort by {sort}.")
 
@@ -38,7 +38,7 @@ class AssetWriter:
     def write(self, fmt=None, path=None, force=False, report=True, sort=None):
         fmt = self._get_format(fmt, path)
         assets = self._sorted(sort)
-        fragments = [fmt.fragments(symbol, data) for symbol, data in assets]
+        fragments = [fmt.fragments(symbol, asset["data"], asset["path"]) for symbol, asset in assets]
         components = {key: [f[key] for f in fragments] for key in fragments[0]}
         outpaths = []
 
@@ -61,8 +61,8 @@ class AssetWriter:
             lines = [
                 f'Formatter: {fmt.name}',
                 'Files:', *(f'    {path}' for path in outpaths),
-                'Assets:', *('    {}: {}'.format(symbol, len(data)) for symbol, data in assets),
-                'Total size: {}'.format(sum(len(data) for symbol, data in assets)),
+                'Assets:', *('    {}: {}'.format(symbol, len(asset["data"])) for symbol, asset in assets),
+                'Total size: {}'.format(sum(len(asset["data"]) for symbol, asset in assets)),
                 '',
             ]
             path.with_name(path.stem + '_report.txt').write_text('\n'.join(lines))

--- a/src/ttblit/tool/packer.py
+++ b/src/ttblit/tool/packer.py
@@ -79,7 +79,7 @@ class Packer(YamlLoader):
 
             aw.write(options.get('type'), self.destination_path / path.name, force=force)
 
-    def build_assets(self, input_files, working_path, name=None, type=None, prefix=None, **builder_options):
+    def build_assets(self, input_files, working_path, name=None, type=None, prefix=None, index=None, **builder_options):
         if type is None:
             # Glob files all have the same suffix, so we only care about the first one
             try:
@@ -110,7 +110,7 @@ class Packer(YamlLoader):
                 input_type=input_type, input_subtype=input_subtype, prefix=prefix
             )
 
-            yield symbol_name, builder.from_file(file, input_subtype, **builder_options)
+            yield symbol_name, builder.from_file(file, input_subtype, **builder_options), index
             logging.info(f' - {typestr} {file} -> {symbol_name}')
 
 


### PR DESCRIPTION
By adding an "index" to an entry in asset.yml, we can remove the need to manually register files with add_buffer_file.
The intent is that File::open would call the generated `get_asset_by_name` function.

Alternatively, it could generate a function that contains multiple add_buffer_file calls, but I'd like to avoid having a large hash map in RAM.

If no asset has an index property, no function is generated, therefore having no impact on existing code.

Example assets.yml:
```yaml
assets.cpp:
  data/mission_1.i16:
    index: data/mission_1.i16
    name: mission_1
    type: raw/binary
```

Example assets.cpp:
```cpp
// Auto Generated File - DO NOT EDIT!
#include <string>
#include <assets.hpp>

const uint8_t mission_1[] = {
...
};

std::pair<const uint8_t*, uint32_t> get_asset_by_name(const std::string& name) {
    struct Entry {
        const char *name;
        const uint8_t *data;
        uint32_t size;
    };
    static const Entry entries[] = {
        {"data/mission_1.i16", mission_1, sizeof(mission_1)}
    };
    for (uint32_t i = 0; i < sizeof(entries)/sizeof(entries[0]); ++i) {
        if (name == entries[i].name)
            return {entries[i].data, entries[i].size};
    }
    return {nullptr, 0};
}
```