### PR TITLE
Use pytest instead of py.test, and test more Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       # Linux deps

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 [testenv]
 commands =
 	python setup.py install
-	coverage run -m py.test -v -r wsx
+	coverage run -m pytest -v -r wsx
 	coverage report
 deps =
 	mock


### PR DESCRIPTION
Apparently `py.test` is no longer a supported way of referring to the pytest module.